### PR TITLE
Remove layout declaration from checkout XML

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <referenceBlock name="space48_gtm_datalayer">
         <block class="Space48\GtmDataLayer\Block\Data\Checkout" name="gtm_datalayer_checkout"/>
     </referenceBlock>


### PR DESCRIPTION
This breaks the checkout header, as it sets the wrong layout.