### PR TITLE
Fix console errors when GTM not configured

### DIFF
--- a/view/frontend/templates/datalayer.phtml
+++ b/view/frontend/templates/datalayer.phtml
@@ -1,7 +1,8 @@
 <!-- GTM Data Layer -->
 <script>
-    var dataLayer = dataLayer || [];
-    <?php echo $block->getChildHtml() ?>
+    if (typeof dataLayer !== 'undefined') {
+        <?php echo $block->getChildHtml() ?>
+    }
 </script>
 <script>
     require([
@@ -10,7 +11,7 @@
 
         var customerSession = tracking.getCookie("customerSession");
 
-        if (customerSession !== null) {
+        if (customerSession !== null && typeof dataLayer !== 'undefined') {
             customerSession = tracking.parseJson(customerSession);
             dataLayer.push(customerSession);
             tracking.delCookie("customerSession");


### PR DESCRIPTION
PR fixes #9 

Instead of setting `dataLayer` to default an empty array, we should check if it is not `undefined`, so as not to potentially try to call a non-existent `push` method on the array.