### PR TITLE
Fix module breaking some layouts after install

### DIFF
--- a/view/frontend/layout/catalog_category_view.xml
+++ b/view/frontend/layout/catalog_category_view.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <referenceBlock name="space48_gtm_datalayer">
         <block class="Space48\GtmDataLayer\Block\Data\CategoryView" name="gtm_datalayer_categoryview"/>
     </referenceBlock>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <referenceBlock name="space48_gtm_datalayer">
         <block class="Space48\GtmDataLayer\Block\Data\ProductView" name="space48_gtm_datalayer_productview"/>
     </referenceBlock>

--- a/view/frontend/layout/catalogsearch_result_index.xml
+++ b/view/frontend/layout/catalogsearch_result_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <referenceBlock name="space48_gtm_datalayer">
         <block class="Space48\GtmDataLayer\Block\Data\SearchResult" name="gtm_datalayer_searchresult"/>
     </referenceBlock>

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <referenceBlock name="space48_gtm_datalayer">
         <block class="Space48\GtmDataLayer\Block\Data\Cart" name="gtm_datalayer_cart"/>
     </referenceBlock>

--- a/view/frontend/layout/checkout_onepage_success.xml
+++ b/view/frontend/layout/checkout_onepage_success.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <referenceBlock name="space48_gtm_datalayer">
         <block class="Space48\GtmDataLayer\Block\Data\OrderSuccess" name="space48_gtm_datalayer_ordersuccess"/>
     </referenceBlock>

--- a/view/frontend/layout/cms_index_index.xml
+++ b/view/frontend/layout/cms_index_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <referenceBlock name="space48_gtm_datalayer">
         <block class="Space48\GtmDataLayer\Block\Data\Homepage" name="gtm_datalayer_homepage"/>
     </referenceBlock>


### PR DESCRIPTION
PR fixes #8 

We are setting the layout for the pages in the XML here, which we should not be doing. The result is broken pages and errors in `system.log`.

Removed the layout attributes from the XML.